### PR TITLE
Add tag to conveniently insert marker components

### DIFF
--- a/examples/dynamic.rs
+++ b/examples/dynamic.rs
@@ -1,8 +1,12 @@
-use bevy::prelude::*;
-use bevy_mod_bbcode::{Bbcode, BbcodeBundle, BbcodePlugin, BbcodeSettings};
+//! This example demonstrates how parts of the text can be efficiently updated dynamically.
+//! To do this, we use the special `[m]` tag, which allows us to assign a marker component to the contained text.
+//! We can then query for the marker component as usual and apply our edits.
 
-#[derive(Debug, Component)]
-struct Marker;
+use bevy::prelude::*;
+use bevy_mod_bbcode::{BbcodeBundle, BbcodePlugin, BbcodeSettings};
+
+#[derive(Component, Clone)]
+struct TimeMarker;
 
 fn main() {
     App::new()
@@ -15,27 +19,20 @@ fn main() {
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn(Camera2dBundle::default());
 
-    commands.spawn((
-        BbcodeBundle::from_content(
-            // The text will be added later
-            "",
-            BbcodeSettings::new(40., Color::WHITE)
-                .with_regular_font(asset_server.load("fonts/FiraSans-Regular.ttf"))
-                .with_bold_font(asset_server.load("fonts/FiraSans-Bold.ttf"))
-                .with_italic_font(asset_server.load("fonts/FiraSans-Italic.ttf")),
-        ),
-        Marker,
+    commands.spawn(BbcodeBundle::from_content(
+        "Time passed: [m=time]0.0[/m] s",
+        BbcodeSettings::new(40., Color::WHITE)
+            .with_regular_font(asset_server.load("fonts/FiraSans-Regular.ttf"))
+            .with_bold_font(asset_server.load("fonts/FiraSans-Bold.ttf"))
+            .with_italic_font(asset_server.load("fonts/FiraSans-Italic.ttf"))
+            // Register the marker component for the `m=time` tag
+            .with_marker("time", TimeMarker),
     ));
 }
 
-fn update(time: Res<Time>, mut query: Query<(&mut Bbcode, &mut BbcodeSettings), With<Marker>>) {
-    let (mut bbcode, mut settings) = query.single_mut();
-
-    // Dynamically change the text to the elapsed time
-    bbcode.content = format!(
-        "Time passed: [b][c=#ffffff]{:.2}[/c][/b]",
-        time.elapsed_seconds()
-    );
-    // Dynamically change the default text color
-    settings.color = Hsla::hsl((time.elapsed_seconds() * 20.) % 360., 1., 0.7).into();
+fn update(time: Res<Time>, mut query: Query<&mut Text, With<TimeMarker>>) {
+    for mut text in query.iter_mut() {
+        // We can directly query for the `Text` component and update it, without the BBCode being parsed again
+        text.sections[0].value = format!("{:.0}", time.elapsed_seconds());
+    }
 }

--- a/examples/dynamic.rs
+++ b/examples/dynamic.rs
@@ -19,14 +19,10 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         BbcodeBundle::from_content(
             // The text will be added later
             "",
-            BbcodeSettings {
-                regular_font: asset_server.load("fonts/FiraSans-Regular.ttf"),
-                bold_font: asset_server.load("fonts/FiraSans-Bold.ttf"),
-                italic_font: asset_server.load("fonts/FiraSans-Italic.ttf"),
-
-                font_size: 40.,
-                color: Color::WHITE,
-            },
+            BbcodeSettings::new(40., Color::WHITE)
+                .with_regular_font(asset_server.load("fonts/FiraSans-Regular.ttf"))
+                .with_bold_font(asset_server.load("fonts/FiraSans-Bold.ttf"))
+                .with_italic_font(asset_server.load("fonts/FiraSans-Italic.ttf")),
         ),
         Marker,
     ));

--- a/examples/static.rs
+++ b/examples/static.rs
@@ -13,13 +13,9 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
 
     commands.spawn(BbcodeBundle::from_content(
         "test [b]bold[/b] with [i]italic[/i] and [c=#ff00ff]color[/c]",
-        BbcodeSettings {
-            regular_font: asset_server.load("fonts/FiraSans-Regular.ttf"),
-            bold_font: asset_server.load("fonts/FiraSans-Bold.ttf"),
-            italic_font: asset_server.load("fonts/FiraSans-Italic.ttf"),
-
-            font_size: 40.,
-            color: Color::WHITE,
-        },
+        BbcodeSettings::new(40., Color::WHITE)
+            .with_regular_font(asset_server.load("fonts/FiraSans-Regular.ttf"))
+            .with_bold_font(asset_server.load("fonts/FiraSans-Bold.ttf"))
+            .with_italic_font(asset_server.load("fonts/FiraSans-Italic.ttf")),
     ));
 }

--- a/src/bevy/bbcode.rs
+++ b/src/bevy/bbcode.rs
@@ -9,12 +9,42 @@ pub struct Bbcode {
 
 #[derive(Debug, Clone, Component)]
 pub struct BbcodeSettings {
-    pub regular_font: Handle<Font>,
-    pub bold_font: Handle<Font>,
-    pub italic_font: Handle<Font>,
-
     pub font_size: f32,
     pub color: Color,
+
+    pub(crate) regular_font: Option<Handle<Font>>,
+    pub(crate) bold_font: Option<Handle<Font>>,
+    pub(crate) italic_font: Option<Handle<Font>>,
+}
+
+impl BbcodeSettings {
+    pub fn new(font_size: f32, color: Color) -> Self {
+        Self {
+            font_size,
+            color,
+            regular_font: None,
+            bold_font: None,
+            italic_font: None,
+        }
+    }
+
+    /// Add a font to use for regular text.
+    pub fn with_regular_font(mut self, handle: Handle<Font>) -> Self {
+        self.regular_font = Some(handle);
+        self
+    }
+
+    /// Add a font to use for bold text.
+    pub fn with_bold_font(mut self, handle: Handle<Font>) -> Self {
+        self.bold_font = Some(handle);
+        self
+    }
+
+    /// Add a font to use for italic text.
+    pub fn with_italic_font(mut self, handle: Handle<Font>) -> Self {
+        self.italic_font = Some(handle);
+        self
+    }
 }
 
 #[derive(Bundle)]

--- a/src/bevy/conversion.rs
+++ b/src/bevy/conversion.rs
@@ -8,10 +8,14 @@ use super::bbcode::{Bbcode, BbcodeSettings};
 
 #[derive(Debug, Clone)]
 struct BbcodeContext {
+    /// Whether the text should be written **bold**.
     is_bold: bool,
+    /// Whether the text should be written *italic*.
     is_italic: bool,
+    /// The color of the text.
     color: Color,
 
+    /// Marker components to apply to the spawned `Text`s.
     markers: Vec<String>,
 }
 
@@ -133,7 +137,7 @@ fn construct_recursively(
                         },
                     ));
 
-                    // Apply marker tags
+                    // Apply marker components
                     for marker in &context.markers {
                         if let Some(modifier) = settings.modifiers.modifier_map.get(marker) {
                             modifier(&mut text_commands);

--- a/src/bevy/conversion.rs
+++ b/src/bevy/conversion.rs
@@ -89,13 +89,21 @@ fn construct_recursively(
     settings: &BbcodeSettings,
     nodes: &Vec<Arc<BbcodeNode>>,
 ) {
+    let default_font = settings.regular_font.clone().unwrap_or_default();
+
     for node in nodes {
         match **node {
             BbcodeNode::Text(ref text) => {
                 let font = match (style.is_bold, style.is_italic) {
-                    (true, _) => settings.bold_font.clone(),
-                    (_, true) => settings.italic_font.clone(),
-                    (false, false) => settings.regular_font.clone(),
+                    (true, _) => default_font.clone(),
+                    (_, true) => settings
+                        .italic_font
+                        .clone()
+                        .unwrap_or_else(|| default_font.clone()),
+                    (false, false) => settings
+                        .regular_font
+                        .clone()
+                        .unwrap_or_else(|| default_font.clone()),
                 };
 
                 entity_commands.with_children(|builder| {


### PR DESCRIPTION
# Objective

Closes #3.

Sometimes, we need parts of the text to be updated dynamically, for example every frame.

We can just adjust the BBCode every frame to accomplish this, e.g. using the `format!` macro, but then we need to parse the BBCode every frame and reconstruct the UI hierarchy.
Needless to say, this doesn't scale very well.

Instead, we want to insert marker components to efficiently query for the `Text` components we need to change.

# Solution

- Add a new `[m=foo]` tag and `BbcodeSettings.with_marker("foo", Foo)` syntax, allowing the user to insert marker components on `Text` entities.
- The marker components can then be used to efficiently update the `Text` (or style) in queries, as usual.
- Additionally, constructing `BbcodeSettings` now uses a builder pattern, which will scale better in the future. (**breaking change**)